### PR TITLE
Reformat code with `mix format`

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,7 @@
+[
+  inputs: [
+    "{lib,test,config}/**/*.{ex,exs}",
+    "*.{ex,exs}"
+  ],
+  line_length: 98
+]

--- a/lib/simhash.ex
+++ b/lib/simhash.ex
@@ -1,7 +1,7 @@
 defmodule Simhash do
   @moduledoc """
   Provides simhash.
-  
+
   ## Examples
 
       iex> Simhash.similarity("Universal Avenue", "Universe Avenue")
@@ -51,14 +51,17 @@ defmodule Simhash do
   Returns list of lists of bits of 64bit Siphashes for each shingle
   """
   def feature_hashes(subject, n) do
-    subject |> n_grams(n) |> Enum.map(&siphash/1) |> Enum.map(&to_list/1)
-  end 
+    subject
+    |> n_grams(n)
+    |> Enum.map(&siphash/1)
+    |> Enum.map(&to_list/1)
+  end
 
   @doc """
   Calculate the similarity between the left and right hash, using Simhash.
   """
   def hash_similarity(left, right) do
-    1 - (hamming_distance(left, right) / 64)
+    1 - hamming_distance(left, right) / 64
   end
 
   @doc """
@@ -69,8 +72,12 @@ defmodule Simhash do
 
   """
   def hamming_distance(left, right) do
-    [left, right] |> List.zip |> Enum.map(&xor/1) |> Enum.sum
+    [left, right]
+    |> List.zip()
+    |> Enum.map(&xor/1)
+    |> Enum.sum()
   end
+
   defp xor({1, 1}), do: 0
   defp xor({1, 0}), do: 1
   defp xor({0, 1}), do: 1
@@ -86,11 +93,14 @@ defmodule Simhash do
 
   """
   def vector_addition(lists) do
-    lists |> List.zip |> Enum.map(&Tuple.to_list/1) |> Enum.map(&Enum.sum/1)
+    lists
+    |> List.zip()
+    |> Enum.map(&Tuple.to_list/1)
+    |> Enum.map(&Enum.sum/1)
   end
 
-  defp to_list(<< 1 :: size(1), data :: bitstring >>), do: [ 1 | to_list(data)]
-  defp to_list(<< 0 :: size(1), data :: bitstring >>), do: [-1 | to_list(data)]
+  defp to_list(<<1::size(1), data::bitstring>>), do: [1 | to_list(data)]
+  defp to_list(<<0::size(1), data::bitstring>>), do: [-1 | to_list(data)]
   defp to_list(<<>>), do: []
 
   defp normalize_bits([head | tail]) when head > 0, do: [1 | normalize_bits(tail)]
@@ -105,7 +115,12 @@ defmodule Simhash do
 
   [More about N-gram](https://en.wikipedia.org/wiki/N-gram#Applications_and_considerations)
   """
-  def n_grams(str, n \\ 3), do: String.graphemes(str) |> Enum.chunk(n, 1) |> Enum.map(&Enum.join/1)
+  def n_grams(str, n \\ 3) do
+    str
+    |> String.graphemes()
+    |> Enum.chunk(n, 1)
+    |> Enum.map(&Enum.join/1)
+  end
 
   @doc """
   Returns the 64bit Siphash for input str as bitstring.
@@ -116,5 +131,5 @@ defmodule Simhash do
       8
 
   """
-  def siphash(str), do: SipHash.hash!("0123456789ABCDEF", str) |> :binary.encode_unsigned
+  def siphash(str), do: SipHash.hash!("0123456789ABCDEF", str) |> :binary.encode_unsigned()
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Simhash.Mixfile do
   def project do
     [app: :simhash,
      version: "0.1.2",
-     elixir: "~> 1.3",
+     elixir: "~> 1.6",
      description: description(),
      package: package(),
      build_embedded: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -2,14 +2,16 @@ defmodule Simhash.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :simhash,
-     version: "0.1.2",
-     elixir: "~> 1.6",
-     description: description(),
-     package: package(),
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps]
+    [
+      app: :simhash,
+      version: "0.1.2",
+      elixir: "~> 1.6",
+      description: description(),
+      package: package(),
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
   end
 
   # Configuration for the OTP application
@@ -22,17 +24,17 @@ defmodule Simhash.Mixfile do
   def package do
     %{
       files: ["lib", "mix.exs", "README.md"],
-      links: %{"GitHub" => "https://github.com/UniversalAvenue/simhash-ex",
-               "Docs" => "https://hexdocs.pm/simhash"},
-      licenses: [ "MIT" ],
-      maintainers: [ "Universal Avenue" ]
+      links: %{
+        "GitHub" => "https://github.com/UniversalAvenue/simhash-ex",
+        "Docs" => "https://hexdocs.pm/simhash"
+      },
+      licenses: ["MIT"],
+      maintainers: ["Universal Avenue"]
     }
   end
 
   defp description do
-    """
-    Simhash implementation using Siphash and N-grams.
-    """
+    "Simhash implementation using Siphash and N-grams."
   end
 
   # Dependencies can be Hex packages:
@@ -45,7 +47,9 @@ defmodule Simhash.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:siphash, "~> 3.1.1"},
-     {:ex_doc, ">= 0.0.0", only: :dev}]
+    [
+      {:siphash, "~> 3.1.1"},
+      {:ex_doc, ">= 0.0.0", only: :dev}
+    ]
   end
 end


### PR DESCRIPTION
This will just make sure that the code is formatted
to make sure we're not causing warnings

*Changes*:
- Update elixir version requirement to 1.6
- Reformat code with `mix format`